### PR TITLE
Add playful SwiftUI expense manager with Dynamic Island live activity

### DIFF
--- a/FinanceToTo/ContentView.swift
+++ b/FinanceToTo/ContentView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+@available(iOS 16.1, *)
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: ExpenseViewModel
+    @EnvironmentObject private var dynamicIslandController: DynamicIslandController
+    @State private var showingAddExpense = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                header
+                progressCard
+                expenseList
+            }
+            .padding()
+            .background(LinearGradient(colors: [.mint.opacity(0.2), .blue.opacity(0.2)], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea())
+            .navigationTitle("Finance ToTo")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        showingAddExpense.toggle()
+                    }) {
+                        Label("Add", systemImage: "plus.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .pink)
+                            .font(.title2)
+                    }
+                    .accessibilityIdentifier("addExpenseButton")
+                }
+            }
+            .sheet(isPresented: $showingAddExpense) {
+                AddExpenseView()
+                    .environmentObject(viewModel)
+                    .presentationDetents([.medium, .large])
+            }
+            .onReceive(viewModel.$shouldTriggerReminder) { shouldTrigger in
+                guard shouldTrigger else { return }
+                dynamicIslandController.triggerReminder(for: viewModel.summary)
+                viewModel.markReminderDelivered()
+            }
+            .task {
+                await dynamicIslandController.requestAuthorization()
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(viewModel.greetingTitle)
+                .font(.largeTitle.bold())
+                .foregroundColor(.primary)
+            Text(viewModel.greetingSubtitle)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+
+    private var progressCard: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Label("Monthly Budget", systemImage: "sparkles")
+                    .font(.headline)
+                Spacer()
+                Text(viewModel.summary.budget, format: .currency(code: viewModel.summary.currencyCode))
+                    .font(.headline)
+            }
+            .foregroundColor(.primary)
+
+            ProgressView(value: viewModel.summary.progress)
+                .tint(.pink)
+                .scaleEffect(x: 1, y: 2, anchor: .center)
+                .accessibilityIdentifier("budgetProgressView")
+
+            HStack {
+                Text("You've spent")
+                Text(viewModel.summary.totalSpent, format: .currency(code: viewModel.summary.currencyCode))
+                    .fontWeight(.bold)
+                    .foregroundColor(viewModel.summary.isOverBudget ? .red : .green)
+                Text("this month on joy sparks!")
+            }
+            .font(.callout)
+            .foregroundColor(.secondary)
+
+            Text(viewModel.summary.statusMessage)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+                .padding(12)
+                .frame(maxWidth: .infinity)
+                .background(viewModel.summary.isOverBudget ? Color.red.opacity(0.15) : Color.green.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .animation(.spring(), value: viewModel.summary.isOverBudget)
+        }
+        .padding()
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    }
+
+    private var expenseList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Recent Adventures")
+                .font(.title2.bold())
+                .foregroundColor(.primary)
+
+            if viewModel.expenses.isEmpty {
+                ContentUnavailableView(
+                    "No Expenses Yet",
+                    systemImage: "star.bubble",
+                    description: Text("Tap the + button to log your sparkly spends!")
+                )
+            } else {
+                List {
+                    ForEach(viewModel.expenses) { expense in
+                        ExpenseRow(expense: expense)
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                    }
+                    .onDelete { indexSet in
+                        withAnimation {
+                            viewModel.remove(atOffsets: indexSet)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#Preview {
+    if #available(iOS 16.1, *) {
+        ContentView()
+            .environmentObject(ExpenseViewModel(preview: true))
+            .environmentObject(DynamicIslandController())
+    } else {
+        Text("Dynamic Island requires iOS 16.1+")
+    }
+}

--- a/FinanceToTo/FinanceToToApp.swift
+++ b/FinanceToTo/FinanceToToApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import ActivityKit
+
+@available(iOS 16.1, *)
+@main
+struct FinanceToToApp: App {
+    @StateObject private var expenseViewModel = ExpenseViewModel()
+    @StateObject private var dynamicIslandController = DynamicIslandController()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(expenseViewModel)
+                .environmentObject(dynamicIslandController)
+        }
+        .commands {
+            SidebarCommands()
+        }
+    }
+}

--- a/FinanceToTo/Models/Expense.swift
+++ b/FinanceToTo/Models/Expense.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+
+struct Expense: Identifiable, Codable, Hashable {
+    let id: UUID
+    var title: String
+    var category: ExpenseCategory
+    var amount: Double
+    var date: Date
+    var currencyCode: String
+
+    init(id: UUID = UUID(), title: String, category: ExpenseCategory, amount: Double, date: Date, currencyCode: String = Locale.current.currency?.identifier ?? "USD") {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.amount = amount
+        self.date = date
+        self.currencyCode = currencyCode
+    }
+
+    var isLarge: Bool {
+        amount >= 50
+    }
+}
+
+extension Expense {
+    static let preview = Expense(title: "Matcha Run", category: .treats, amount: 14, date: .now)
+}

--- a/FinanceToTo/Models/ExpenseActivityAttributes.swift
+++ b/FinanceToTo/Models/ExpenseActivityAttributes.swift
@@ -1,0 +1,16 @@
+import Foundation
+import ActivityKit
+
+@available(iOS 16.1, *)
+struct ExpenseActivityAttributes: ActivityAttributes {
+    public typealias ContentState = DynamicIslandState
+
+    struct DynamicIslandState: Codable, Hashable {
+        var totalSpent: Double
+        var remainingBudget: Double
+        var isOverBudget: Bool
+    }
+
+    var budget: Double
+    var currencyCode: String
+}

--- a/FinanceToTo/Models/ExpenseCategory.swift
+++ b/FinanceToTo/Models/ExpenseCategory.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+enum ExpenseCategory: String, CaseIterable, Identifiable, Codable {
+    case treats
+    case travel
+    case essentials
+    case wellness
+    case learning
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .treats: return "Treat Yourself"
+        case .travel: return "Tiny Trips"
+        case .essentials: return "Essentials"
+        case .wellness: return "Wellness"
+        case .learning: return "Curious Mind"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .treats: return "cup.and.saucer.fill"
+        case .travel: return "airplane"
+        case .essentials: return "cart.fill"
+        case .wellness: return "heart.circle.fill"
+        case .learning: return "book.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .treats: return .pink
+        case .travel: return .blue
+        case .essentials: return .purple
+        case .wellness: return .green
+        case .learning: return .orange
+        }
+    }
+}

--- a/FinanceToTo/Models/ExpenseSummary.swift
+++ b/FinanceToTo/Models/ExpenseSummary.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct ExpenseSummary: Codable {
+    var budget: Double
+    var totalSpent: Double
+    var currencyCode: String
+
+    var progress: Double {
+        guard budget > 0 else { return 0 }
+        return min(totalSpent / budget, 1.2)
+    }
+
+    var remaining: Double {
+        max(budget - totalSpent, 0)
+    }
+
+    var isOverBudget: Bool {
+        totalSpent > budget
+    }
+
+    var statusMessage: String {
+        if isOverBudget {
+            return "Whoa! You're on a glitter spree. Let's slow the sparkle." + reminderHint
+        } else if progress > 0.8 {
+            return "Almost at your budget. Maybe a cozy night in?" + reminderHint
+        } else if progress > 0.4 {
+            return "You're balancing joy and savings like a pro!"
+        } else {
+            return "Plenty of sparkle room left. Enjoy mindfully!"
+        }
+    }
+
+    private var reminderHint: String {
+        "\nDynamic Island will nudge you if things get too twinkly."
+    }
+}
+
+extension ExpenseSummary {
+    static let preview = ExpenseSummary(budget: 500, totalSpent: 320, currencyCode: "USD")
+}

--- a/FinanceToTo/Services/DynamicIslandController.swift
+++ b/FinanceToTo/Services/DynamicIslandController.swift
@@ -1,0 +1,38 @@
+import Foundation
+import ActivityKit
+
+@available(iOS 16.1, *)
+@MainActor
+final class DynamicIslandController: ObservableObject {
+    private var currentActivity: Activity<ExpenseActivityAttributes>?
+
+    func requestAuthorization() async {
+        let info = ActivityAuthorizationInfo()
+        guard info.areActivitiesEnabled else { return }
+        _ = await ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    func triggerReminder(for summary: ExpenseSummary) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let attributes = ExpenseActivityAttributes(budget: summary.budget, currencyCode: summary.currencyCode)
+        let state = ExpenseActivityAttributes.ContentState(
+            totalSpent: summary.totalSpent,
+            remainingBudget: summary.remaining,
+            isOverBudget: summary.isOverBudget
+        )
+
+        if let currentActivity {
+            Task { await currentActivity.update(using: state) }
+        } else {
+            currentActivity = try? Activity.request(attributes: attributes, contentState: state, pushType: nil)
+        }
+    }
+
+    func endActivity() {
+        Task {
+            await currentActivity?.end(dismissalPolicy: .default)
+            currentActivity = nil
+        }
+    }
+}

--- a/FinanceToTo/Services/ExpenseStorage.swift
+++ b/FinanceToTo/Services/ExpenseStorage.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol ExpenseStorage {
+    func loadExpenses() -> [Expense]
+    func save(expenses: [Expense])
+}
+
+struct FileExpenseStorage: ExpenseStorage {
+    private let url: URL
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    init(filename: String = "expenses.json") {
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        url = documentsURL.appendingPathComponent(filename)
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+
+    func loadExpenses() -> [Expense] {
+        guard let data = try? Data(contentsOf: url) else { return [] }
+        return (try? decoder.decode([Expense].self, from: data)) ?? []
+    }
+
+    func save(expenses: [Expense]) {
+        guard let data = try? encoder.encode(expenses) else { return }
+        try? data.write(to: url)
+    }
+}
+
+struct InMemoryExpenseStorage: ExpenseStorage {
+    private var sampleExpenses: [Expense]
+
+    init() {
+        sampleExpenses = [
+            Expense(title: "Boba Joy", category: .treats, amount: 8.5, date: .now.addingTimeInterval(-3600)),
+            Expense(title: "Mini Spa Day", category: .wellness, amount: 62, date: .now.addingTimeInterval(-86400)),
+            Expense(title: "Books & Chill", category: .learning, amount: 28, date: .now.addingTimeInterval(-172800))
+        ]
+    }
+
+    func loadExpenses() -> [Expense] { sampleExpenses }
+
+    func save(expenses: [Expense]) { }
+}

--- a/FinanceToTo/Services/ReminderService.swift
+++ b/FinanceToTo/Services/ReminderService.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Combine
+import UserNotifications
+
+protocol ReminderService {
+    var currentBudget: Double { get }
+    var budgetPublisher: AnyPublisher<Double, Never> { get }
+    func scheduleReminder(for summary: ExpenseSummary)
+}
+
+final class BudgetReminderService: NSObject, ReminderService, UNUserNotificationCenterDelegate {
+    private(set) var currentBudget: Double
+    private let center = UNUserNotificationCenter.current()
+    private let subject: CurrentValueSubject<Double, Never>
+
+    override init() {
+        let defaultBudget = UserDefaults.standard.double(forKey: "monthlyBudget")
+        currentBudget = defaultBudget == 0 ? 600 : defaultBudget
+        subject = CurrentValueSubject(currentBudget)
+        super.init()
+        center.delegate = self
+        requestNotificationPermission()
+    }
+
+    var budgetPublisher: AnyPublisher<Double, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func updateBudget(to newValue: Double) {
+        currentBudget = newValue
+        UserDefaults.standard.set(newValue, forKey: "monthlyBudget")
+        subject.send(newValue)
+    }
+
+    func scheduleReminder(for summary: ExpenseSummary) {
+        let content = UNMutableNotificationContent()
+        content.title = summary.isOverBudget ? "Budget SOS" : "Sparkle Alert"
+        let overBudgetAmount = summary.totalSpent - summary.budget
+        content.body = summary.isOverBudget
+            ? "You're over budget by \(overBudgetAmount, format: .currency(code: summary.currencyCode)). Time for a chill night?"
+            : "You've used \(Int(summary.progress * 100))% of your budget. Maybe review your wishlist?"
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+        center.add(request)
+    }
+
+    private func requestNotificationPermission() {
+        center.requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+    }
+}
+
+struct PreviewReminderService: ReminderService {
+    var currentBudget: Double = 800
+    var budgetPublisher: AnyPublisher<Double, Never> = Just(800).eraseToAnyPublisher()
+
+    func scheduleReminder(for summary: ExpenseSummary) { }
+}

--- a/FinanceToTo/ViewModels/ExpenseViewModel.swift
+++ b/FinanceToTo/ViewModels/ExpenseViewModel.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Combine
+
+@MainActor
+final class ExpenseViewModel: ObservableObject {
+    @Published private(set) var expenses: [Expense] = []
+    @Published private(set) var summary: ExpenseSummary
+    @Published var shouldTriggerReminder: Bool = false
+
+    private let storage: any ExpenseStorage
+    private let reminderService: any ReminderService
+    private var cancellables = Set<AnyCancellable>()
+
+    init(storage: any ExpenseStorage = FileExpenseStorage(), reminderService: any ReminderService = BudgetReminderService(), preview: Bool = false) {
+        if preview {
+            let previewStorage = InMemoryExpenseStorage()
+            let previewReminder = PreviewReminderService()
+            self.storage = previewStorage
+            self.reminderService = previewReminder
+
+            let sampleExpenses = previewStorage.loadExpenses()
+            expenses = sampleExpenses
+            summary = Self.makeSummary(from: sampleExpenses, budget: previewReminder.currentBudget)
+        } else {
+            self.storage = storage
+            self.reminderService = reminderService
+
+            let stored = storage.loadExpenses()
+            expenses = stored
+            summary = Self.makeSummary(from: stored, budget: reminderService.currentBudget)
+        }
+
+        setupSubscriptions()
+    }
+
+    var greetingTitle: String {
+        "Hello, Sunshine!"
+    }
+
+    var greetingSubtitle: String {
+        "Let's keep your sparkle fund smiling."
+    }
+
+    var randomAffirmation: String {
+        [
+            "Every coin you keep is a future adventure!",
+            "You deserve joy and stability—go you!",
+            "Budgeting is self-care with glitter.",
+            "Tiny mindful choices grow mighty dreams."
+        ].randomElement() ?? "You're doing amazing!"
+    }
+
+    func canSaveExpense(title: String, amount: Double) -> Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && amount > 0
+    }
+
+    func addExpense(title: String, category: ExpenseCategory, amount: Double, date: Date) {
+        let newExpense = Expense(title: title, category: category, amount: amount, date: date, currencyCode: summary.currencyCode)
+        expenses.insert(newExpense, at: 0)
+        storage.save(expenses: expenses)
+        updateSummary()
+    }
+
+    func remove(atOffsets offsets: IndexSet) {
+        expenses.remove(atOffsets: offsets)
+        storage.save(expenses: expenses)
+        updateSummary()
+    }
+
+    func markReminderDelivered() {
+        shouldTriggerReminder = false
+    }
+
+    private func updateSummary() {
+        summary = Self.makeSummary(from: expenses, budget: reminderService.currentBudget)
+        evaluateReminder()
+    }
+
+    private func evaluateReminder() {
+        shouldTriggerReminder = summary.isOverBudget || summary.progress > 0.85
+        if shouldTriggerReminder {
+            reminderService.scheduleReminder(for: summary)
+        }
+    }
+
+    private func setupSubscriptions() {
+        reminderService.budgetPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newBudget in
+                guard let self else { return }
+                summary = Self.makeSummary(from: expenses, budget: newBudget)
+                evaluateReminder()
+            }
+            .store(in: &cancellables)
+    }
+
+    private static func makeSummary(from expenses: [Expense], budget: Double) -> ExpenseSummary {
+        let total = expenses.reduce(0) { $0 + $1.amount }
+        return ExpenseSummary(budget: budget, totalSpent: total, currencyCode: Locale.current.currency?.identifier ?? "USD")
+    }
+}

--- a/FinanceToTo/Views/AddExpenseView.swift
+++ b/FinanceToTo/Views/AddExpenseView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct AddExpenseView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var viewModel: ExpenseViewModel
+
+    @State private var title: String = ""
+    @State private var category: ExpenseCategory = .treats
+    @State private var amount: Double = 0
+    @State private var date: Date = .now
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    TextField("What did you enjoy?", text: $title)
+                        .textInputAutocapitalization(.sentences)
+                    Picker("Category", selection: $category) {
+                        ForEach(ExpenseCategory.allCases) { category in
+                            Label(category.title, systemImage: category.symbol)
+                                .tag(category)
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+                }
+
+                Section("Cost") {
+                    TextField("Amount", value: $amount, format: .currency(code: viewModel.summary.currencyCode))
+                        .keyboardType(.decimalPad)
+                    DatePicker("When did it happen?", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                }
+
+                Section("Mood Boost") {
+                    Text(viewModel.randomAffirmation)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                        .listRowBackground(Color.orange.opacity(0.1))
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Color.orange.opacity(0.08))
+            .navigationTitle("Log Expense")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        withAnimation(.spring()) {
+                            viewModel.addExpense(title: title, category: category, amount: amount, date: date)
+                            dismiss()
+                        }
+                    }
+                    .disabled(!viewModel.canSaveExpense(title: title, amount: amount))
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AddExpenseView()
+        .environmentObject(ExpenseViewModel(preview: true))
+}

--- a/FinanceToTo/Views/ExpenseRow.swift
+++ b/FinanceToTo/Views/ExpenseRow.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ExpenseRow: View {
+    let expense: Expense
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(expense.category.color.gradient)
+                    .frame(width: 48, height: 48)
+                Image(systemName: expense.category.symbol)
+                    .font(.title3)
+                    .foregroundColor(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(expense.title)
+                    .font(.headline)
+                Text(expense.category.title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(expense.date, style: .date)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+
+            Text(expense.amount, format: .currency(code: expense.currencyCode))
+                .font(.headline)
+                .foregroundColor(expense.isLarge ? .red : .primary)
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: expense.category.color.opacity(0.2), radius: 6, x: 0, y: 4)
+    }
+}
+
+#Preview {
+    ExpenseRow(expense: Expense.preview)
+        .padding()
+        .background(Color(.systemGroupedBackground))
+}

--- a/FinanceToToWidget/FinanceToToWidget.swift
+++ b/FinanceToToWidget/FinanceToToWidget.swift
@@ -1,0 +1,90 @@
+import WidgetKit
+import SwiftUI
+import ActivityKit
+
+struct FinanceToToWidgetEntryView: View {
+    let context: ActivityViewContext<ExpenseActivityAttributes>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(context.state.isOverBudget ? "Over Budget!" : "Keep Gliding ✨")
+                .font(.headline)
+                .foregroundColor(context.state.isOverBudget ? .red : .white)
+            Text("Spent: \(context.state.totalSpent, format: .currency(code: context.attributes.currencyCode))")
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.9))
+            Text("Left: \(context.state.remainingBudget, format: .currency(code: context.attributes.currencyCode))")
+                .font(.caption2)
+                .foregroundColor(.white.opacity(0.7))
+            ProgressView(value: min(context.state.totalSpent / context.attributes.budget, 1))
+                .tint(.white)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(context.state.isOverBudget ? Color.red.gradient : Color.blue.gradient)
+    }
+}
+
+@available(iOS 16.1, *)
+@main
+struct FinanceToToWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: ExpenseActivityAttributes.self) { context in
+            FinanceToToWidgetEntryView(context: context)
+                .activityBackgroundTint(Color.black.opacity(0.85))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Image(systemName: "sparkles")
+                        Text("Budget: \(context.attributes.budget, format: .currency(code: context.attributes.currencyCode))")
+                            .font(.caption2)
+                    }
+                    .foregroundColor(.white)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 6) {
+                        Text("Spent")
+                            .font(.caption)
+                        Text(context.state.totalSpent, format: .currency(code: context.attributes.currencyCode))
+                            .font(.headline)
+                            .foregroundColor(context.state.isOverBudget ? .yellow : .white)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(context.state.isOverBudget ? "Time to pause the party!" : "You're glowing on track.")
+                            .font(.subheadline)
+                        ProgressView(value: min(context.state.totalSpent / context.attributes.budget, 1))
+                            .progressViewStyle(.linear)
+                            .tint(context.state.isOverBudget ? .yellow : .mint)
+                    }
+                    .foregroundColor(.white)
+                }
+            } compactLeading: {
+                Image(systemName: context.state.isOverBudget ? "exclamationmark.triangle.fill" : "sparkles")
+                    .foregroundColor(.white)
+            } compactTrailing: {
+                Text(context.state.totalSpent, format: .currency(code: context.attributes.currencyCode))
+                    .font(.caption2)
+                    .foregroundColor(.white)
+            } minimal: {
+                Image(systemName: context.state.isOverBudget ? "flame.fill" : "leaf.fill")
+                    .symbolRenderingMode(.hierarchical)
+            }
+        }
+    }
+}
+
+#Preview("Dynamic Island") {
+    if #available(iOS 16.1, *) {
+        FinanceToToWidgetEntryView(
+            context: .init(
+                attributes: ExpenseActivityAttributes(budget: 500, currencyCode: "USD"),
+                state: ExpenseActivityAttributes.ContentState(totalSpent: 520, remainingBudget: 0, isOverBudget: true)
+            )
+        )
+        .previewContext(WidgetPreviewContext(family: .systemMedium))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Finance ToTo
+
+Finance ToTo is a playful SwiftUI budgeting companion designed for iPhone. It keeps spending joyful yet mindful with vibrant visuals, gentle affirmations, and timely reminders delivered straight from the Dynamic Island.
+
+## Features
+
+- **SwiftUI-first experience** with whimsical gradients, bubbly typography, and friendly copy.
+- **Expense tracking** across themed categories such as treats, travel, wellness, and more.
+- **Budget awareness** card with progress tracking, emoji-fueled status messages, and quick add sheet.
+- **Dynamic Island live activity** that surfaces remaining budget, spending alerts, and motivational nudges even when the app is backgrounded.
+- **Notifications & reminders** triggered automatically when spending grows intense, keeping users mindful of their sparkle fund.
+
+## Architecture
+
+The project follows a lightweight MVVM approach:
+
+- `ExpenseViewModel` orchestrates business logic, handles storage, and evaluates when to trigger reminders.
+- `ExpenseStorage` persists expenses on-device.
+- `ReminderService` wraps notification scheduling and budget publishing.
+- `DynamicIslandController` manages ActivityKit live activities for the Dynamic Island.
+- `FinanceToToWidget` renders the live activity and Dynamic Island regions.
+
+## Requirements
+
+- Xcode 15+
+- iOS 17+ (ActivityKit v2 for Dynamic Island customizations)
+
+## Getting Started
+
+1. Open the project in Xcode.
+2. Ensure the app target has the `ActivityKit` and `UserNotifications` capabilities enabled.
+3. Run on a physical device with Dynamic Island support (iPhone 14 Pro or newer) to experience the live activity prompts.
+
+## Customization Ideas
+
+- Adjust the default monthly budget in `BudgetReminderService`.
+- Extend `ExpenseCategory` with additional categories or icons.
+- Enhance analytics by syncing with CloudKit or integrating charts.
+- Localize the whimsical copy to match regional vibes.


### PR DESCRIPTION
## Summary
- scaffold a SwiftUI iPhone app with joyful budget tracking screens, expense entry flow, and categorized list styling
- implement persistence, reminders, and budget evaluation logic to trigger notifications and Dynamic Island updates
- add an ActivityKit-powered widget extension that surfaces live spending alerts and playful messaging from the Dynamic Island

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5ea861670832693645f97bc218a26