### PR TITLE
Create SwiftUI budgeting experience with Dynamic Island reminders

### DIFF
--- a/TOTO/BudgetModels.swift
+++ b/TOTO/BudgetModels.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftUI
+
+struct Expense: Identifiable {
+    let id = UUID()
+    var amount: Double
+    var note: String
+    var date: Date
+}
+
+struct BudgetCategory: Identifiable {
+    let id = UUID()
+    var name: String
+    var icon: String
+    var color: Color
+    var limit: Double
+    var expenses: [Expense] = []
+
+    var spent: Double {
+        expenses.reduce(0) { $0 + $1.amount }
+    }
+
+    var progress: Double {
+        guard limit > 0 else { return 0 }
+        return min(spent / limit, 1)
+    }
+
+    var remaining: Double {
+        max(limit - spent, 0)
+    }
+
+    var friendlyLimitDescription: String {
+        "Mức giới hạn: \(limit, format: .currency(code: Locale.current.currency?.identifier ?? "VND"))"
+    }
+}
+
+final class BudgetViewModel: ObservableObject {
+    @Published var categories: [BudgetCategory]
+    @Published var lastReminder: FriendlyReminderMessage?
+    @Published var activeCategory: BudgetCategory?
+
+    let userName: String
+    private let speaker = FriendlySpeaker()
+
+    init(userName: String = "ToTo") {
+        self.userName = userName
+        self.categories = BudgetViewModel.defaultCategories
+    }
+
+    func prepareAudioSession() {
+        speaker.prepare()
+    }
+
+    func addExpense(amount: Double, note: String, date: Date = .now, to category: BudgetCategory) {
+        guard let index = categories.firstIndex(where: { $0.id == category.id }) else { return }
+        let expense = Expense(amount: amount, note: note, date: date)
+        categories[index].expenses.insert(expense, at: 0)
+        let updatedCategory = categories[index]
+        let reminder = FriendlyReminder.message(for: updatedCategory, newExpense: amount, userName: userName)
+        lastReminder = reminder
+        speaker.speak(reminder.voiceLine)
+
+        if #available(iOS 16.1, *) {
+            LiveActivityBridge.shared.startOrUpdate(with: updatedCategory, reminder: reminder, userName: userName)
+        }
+    }
+}
+
+private extension BudgetViewModel {
+    static var defaultCategories: [BudgetCategory] {
+        [
+            BudgetCategory(
+                name: "Ăn uống",
+                icon: "fork.knife",
+                color: Color.pink,
+                limit: 1_500_000,
+                expenses: [
+                    Expense(amount: 120_000, note: "Cà phê sáng", date: .now.addingTimeInterval(-7200)),
+                    Expense(amount: 85_000, note: "Bánh mì kẹp", date: .now.addingTimeInterval(-36_000))
+                ]
+            ),
+            BudgetCategory(
+                name: "Di chuyển",
+                icon: "car.fill",
+                color: Color.blue,
+                limit: 800_000,
+                expenses: [
+                    Expense(amount: 150_000, note: "Grab đi làm", date: .now.addingTimeInterval(-18_000))
+                ]
+            ),
+            BudgetCategory(
+                name: "Giải trí",
+                icon: "sparkles",
+                color: Color.purple,
+                limit: 600_000,
+                expenses: [
+                    Expense(amount: 220_000, note: "Rạp phim cuối tuần", date: .now.addingTimeInterval(-200_000))
+                ]
+            )
+        ]
+    }
+}

--- a/TOTO/ContentView.swift
+++ b/TOTO/ContentView.swift
@@ -1,25 +1,250 @@
-//
-//  ContentView.swift
-//  TOTO
-//
-//  Created by Thơ Anh Đỗ on 8/10/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = BudgetViewModel()
+    @State private var showingAddSheet = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            ZStack {
+                LinearGradient(colors: [.black.opacity(0.9), .indigo.opacity(0.6)], startPoint: .top, endPoint: .bottom)
+                    .ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        header
+                        reminderBanner
+                        ForEach(viewModel.categories) { category in
+                            CategoryCard(category: category) {
+                                viewModel.activeCategory = category
+                                showingAddSheet = true
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 32)
+                    .padding(.top, 16)
+                }
+            }
+            .navigationTitle("TOTO Finance")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        viewModel.activeCategory = viewModel.categories.first
+                        showingAddSheet = true
+                    } label: {
+                        Label("Thêm chi tiêu", systemImage: "plus")
+                    }
+                }
+            }
         }
-        .padding()
+        .sheet(isPresented: $showingAddSheet, onDismiss: { viewModel.activeCategory = nil }) {
+            if let category = viewModel.activeCategory {
+                AddExpenseSheet(category: category) { amount, note, date in
+                    viewModel.addExpense(amount: amount, note: note, date: date, to: category)
+                }
+                .presentationDetents([.medium, .large])
+            }
+        }
+        .onAppear {
+            viewModel.prepareAudioSession()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Xin chào, \(viewModel.userName) ✨")
+                .font(.largeTitle.bold())
+                .foregroundStyle(.white)
+            Text("Theo dõi chi tiêu mỗi ngày với nhắc nhở đáng yêu từ TOTO và Dynamic Island.")
+                .font(.callout)
+                .foregroundStyle(.white.opacity(0.8))
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+
+    private var reminderBanner: some View {
+        Group {
+            if let reminder = viewModel.lastReminder {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(reminder.title, systemImage: "bubble.left.and.bubble.right.fill")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Text(reminder.subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(reminder.tone.accentColor.opacity(0.65), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Hôm nay bạn muốn khám phá hạng mục nào?", systemImage: "sparkles")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Text("TOTO sẽ nhẹ nhàng nhắc nhở khi chi tiêu vượt kế hoạch. Bắt đầu bằng cách thêm giao dịch đầu tiên nhé!")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            }
+        }
+    }
+}
+
+private struct CategoryCard: View {
+    var category: BudgetCategory
+    var onAddExpense: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: category.icon)
+                    .font(.title2)
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+                    .background(category.color.opacity(0.7), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(category.name)
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Text(category.friendlyLimitDescription)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                Spacer()
+                Button(action: onAddExpense) {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(.white)
+                        .font(.title2)
+                        .shadow(radius: 4)
+                }
+                .buttonStyle(.plain)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                ProgressView(value: category.progress)
+                    .tint(category.color)
+                    .progressViewStyle(.linear)
+                    .frame(height: 10)
+                    .background(Color.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Đã chi")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                        Text(category.spent, format: .currency(code: Locale.current.currency?.identifier ?? "VND"))
+                            .font(.callout.bold())
+                            .foregroundStyle(.white)
+                    }
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text("Còn lại")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                        Text(category.remaining, format: .currency(code: Locale.current.currency?.identifier ?? "VND"))
+                            .font(.callout.bold())
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Giao dịch gần đây")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.white)
+                if category.expenses.isEmpty {
+                    Text("Chưa có giao dịch nào. Thêm mới để TOTO cổ vũ bạn nhé!")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.6))
+                } else {
+                    ForEach(category.expenses.prefix(3)) { expense in
+                        ExpenseRow(expense: expense)
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    }
+}
+
+private struct ExpenseRow: View {
+    var expense: Expense
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color.white.opacity(0.25))
+                .frame(width: 34, height: 34)
+                .overlay(
+                    Image(systemName: "sparkle")
+                        .font(.footnote)
+                        .foregroundStyle(.white)
+                )
+            VStack(alignment: .leading, spacing: 4) {
+                Text(expense.note)
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                Text(expense.date, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            Spacer()
+            Text(expense.amount, format: .currency(code: Locale.current.currency?.identifier ?? "VND"))
+                .font(.subheadline.bold())
+                .foregroundStyle(.white)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct AddExpenseSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    var category: BudgetCategory
+    var onSave: (Double, String, Date) -> Void
+
+    @State private var amount: Double = 100_000
+    @State private var note: String = ""
+    @State private var date: Date = .now
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Chi tiêu cho \(category.name)")) {
+                    TextField("Ghi chú", text: $note)
+                    HStack {
+                        Text("Số tiền")
+                        Spacer()
+                        TextField("0", value: $amount, format: .currency(code: Locale.current.currency?.identifier ?? "VND"))
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.decimalPad)
+                    }
+                    DatePicker("Thời gian", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                }
+            }
+            .navigationTitle("Thêm chi tiêu")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Đóng") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Lưu") {
+                        onSave(amount, note.isEmpty ? "Chi tiêu dễ thương" : note, date)
+                        dismiss()
+                    }
+                    .disabled(amount <= 0)
+                }
+            }
+        }
     }
 }
 
 #Preview {
     ContentView()
 }
-

--- a/TOTO/FriendlyReminder.swift
+++ b/TOTO/FriendlyReminder.swift
@@ -1,0 +1,86 @@
+import Foundation
+import AVFoundation
+import SwiftUI
+
+enum ReminderTone {
+    case celebrate
+    case gentle
+    case warning
+
+    var accentColor: Color {
+        switch self {
+        case .celebrate:
+            return .green
+        case .gentle:
+            return .orange
+        case .warning:
+            return .red
+        }
+    }
+}
+
+struct FriendlyReminderMessage: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String
+    let voiceLine: String
+    let tone: ReminderTone
+
+    var compactMessage: String {
+        "\(title) • \(subtitle)"
+    }
+}
+
+struct FriendlyReminder {
+    static func message(for category: BudgetCategory, newExpense: Double, userName: String) -> FriendlyReminderMessage {
+        let spent = category.spent
+        let limit = category.limit
+        let percent = limit > 0 ? spent / limit : 0
+        let currencyFormatter = NumberFormatter()
+        currencyFormatter.numberStyle = .currency
+        currencyFormatter.currencyCode = Locale.current.currency?.identifier ?? "VND"
+        let amountText = currencyFormatter.string(from: NSNumber(value: newExpense)) ?? "\(newExpense)"
+        let spentText = currencyFormatter.string(from: NSNumber(value: spent)) ?? "\(spent)"
+        let limitText = currencyFormatter.string(from: NSNumber(value: limit)) ?? "\(limit)"
+
+        if spent > limit {
+            let title = "Ôi không! Chi tiêu vượt \(category.name) mất rồi"
+            let subtitle = "Tổng chi hiện tại là \(spentText)/\(limitText). Cùng hít thở và cân nhắc tiết chế nhé \(userName)!"
+            let voice = "Bạn \(userName) ơi, hạt dẻ nhỏ của TOTO đã vượt mức cho \(category.name) rồi nè. Mình cùng nghỉ ngơi một chút nhé!"
+            return FriendlyReminderMessage(title: title, subtitle: subtitle, voiceLine: voice, tone: .warning)
+        } else if percent > 0.85 {
+            let title = "Sắp chạm giới hạn \(category.name) rồi"
+            let subtitle = "Bạn đã tiêu \(spentText) trong khi giới hạn là \(limitText). TOTO tin bạn sẽ điều chỉnh hợp lý!"
+            let voice = "Ui chao, chỉ còn chút xíu nữa thôi là chạm trần \(category.name) rồi đó \(userName)! Cố lên nè!"
+            return FriendlyReminderMessage(title: title, subtitle: subtitle, voiceLine: voice, tone: .gentle)
+        } else {
+            let title = "\(category.name) thêm một niềm vui mới"
+            let subtitle = "Bạn vừa tiêu \(amountText). Tổng chi hiện tại: \(spentText)/\(limitText)."
+            let voice = "Yeah! \(amountText) cho \(category.name) nghe thật đáng yêu đó \(userName)! Hãy tận hưởng nhưng vẫn nhớ kế hoạch nha."
+            return FriendlyReminderMessage(title: title, subtitle: subtitle, voiceLine: voice, tone: .celebrate)
+        }
+    }
+}
+
+final class FriendlySpeaker {
+    private let synthesizer = AVSpeechSynthesizer()
+    private var isPrepared = false
+
+    func prepare() {
+        guard !isPrepared else { return }
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.playback, mode: .spokenAudio, options: [.mixWithOthers])
+        try? session.setActive(true, options: [])
+        isPrepared = true
+    }
+
+    func speak(_ text: String) {
+        guard !text.isEmpty else { return }
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "vi-VN")
+        utterance.pitchMultiplier = 1.1
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate * 0.9
+        synthesizer.stopSpeaking(at: .immediate)
+        synthesizer.speak(utterance)
+    }
+}

--- a/TOTO/LiveActivityManager.swift
+++ b/TOTO/LiveActivityManager.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+#if canImport(ActivityKit)
+import ActivityKit
+
+@available(iOS 16.1, *)
+struct BudgetActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var categoryName: String
+        var spent: Double
+        var limit: Double
+        var message: String
+    }
+
+    var userName: String
+}
+
+@available(iOS 16.1, *)
+final class LiveActivityBridge {
+    static let shared = LiveActivityBridge()
+
+    private var activity: Activity<BudgetActivityAttributes>?
+
+    func startOrUpdate(with category: BudgetCategory, reminder: FriendlyReminderMessage, userName: String) {
+        let contentState = BudgetActivityAttributes.ContentState(
+            categoryName: category.name,
+            spent: category.spent,
+            limit: category.limit,
+            message: reminder.compactMessage
+        )
+        Task {
+            if let activity {
+                await activity.update(ActivityContent(state: contentState, staleDate: .now.addingTimeInterval(3600)))
+            } else {
+                let attributes = BudgetActivityAttributes(userName: userName)
+                do {
+                    activity = try Activity.request(
+                        attributes: attributes,
+                        content: ActivityContent(state: contentState, staleDate: .now.addingTimeInterval(3600)),
+                        pushType: nil
+                    )
+                } catch {
+                    #if DEBUG
+                    print("Không thể tạo Live Activity: \(error)")
+                    #endif
+                }
+            }
+        }
+    }
+
+    func endActivity() {
+        Task {
+            await activity?.end(nil, dismissalPolicy: .immediate)
+            activity = nil
+        }
+    }
+}
+#else
+final class LiveActivityBridge {
+    static let shared = LiveActivityBridge()
+
+    func startOrUpdate(with category: BudgetCategory, reminder: FriendlyReminderMessage, userName: String) { }
+    func endActivity() { }
+}
+#endif

--- a/TOTO/TOTOApp.swift
+++ b/TOTO/TOTOApp.swift
@@ -1,17 +1,18 @@
-//
-//  TOTOApp.swift
-//  TOTO
-//
-//  Created by Thơ Anh Đỗ on 8/10/25.
-//
-
 import SwiftUI
 
 @main
 struct TOTOApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+        .onChange(of: scenePhase) { newPhase in
+            guard newPhase == .inactive else { return }
+            if #available(iOS 16.1, *) {
+                LiveActivityBridge.shared.endActivity()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add budgeting domain models and a view model that triggers cheerful reminders and speech feedback
- redesign the main content view with gradient styling, category cards, and an add-expense sheet
- integrate a Live Activity bridge so spending alerts surface on Dynamic Island and close activities on app exit

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68e60f864bd48326a2129b2cbf6c9ace